### PR TITLE
Add CLI version/variable commands and tighten flag validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,10 @@ if(BUILD_TESTING)
   add_subdirectory(tests)
   enable_testing()
 
+  set(TEST_WORKDIR_EMPTY_VARS "${CMAKE_BINARY_DIR}/test_workdirs/empty_vars")
+  file(MAKE_DIRECTORY ${TEST_WORKDIR_EMPTY_VARS})
+  file(REMOVE ${TEST_WORKDIR_EMPTY_VARS}/vars.toml)
+
   add_test(
     NAME calculator_eval_basic
     COMMAND ${CMAKE_COMMAND}
@@ -57,6 +61,43 @@ if(BUILD_TESTING)
       "-Dargs=--no-color;--square-root;-9"
       -Dexpected_exit_code=1
       "-Dpattern=square root undefined for negative values"
+      -P ${CMAKE_SOURCE_DIR}/cmake/run_with_expectations.cmake)
+
+  add_test(
+    NAME calculator_version
+    COMMAND ${CMAKE_COMMAND}
+      -Dcmd=$<TARGET_FILE:calculator>
+      "-Dargs=--no-color;--version"
+      -Dexpected_exit_code=0
+      "-Dpattern=CLI Calculator version[ ]${PROJECT_VERSION}"
+      -P ${CMAKE_SOURCE_DIR}/cmake/run_with_expectations.cmake)
+
+  add_test(
+    NAME calculator_unknown_flag
+    COMMAND ${CMAKE_COMMAND}
+      -Dcmd=$<TARGET_FILE:calculator>
+      "-Dargs=--no-color;--bogus"
+      -Dexpected_exit_code=1
+      "-Dpattern=unknown argument: --bogus"
+      -P ${CMAKE_SOURCE_DIR}/cmake/run_with_expectations.cmake)
+
+  add_test(
+    NAME calculator_output_without_action
+    COMMAND ${CMAKE_COMMAND}
+      -Dcmd=$<TARGET_FILE:calculator>
+      "-Dargs=--output;json"
+      -Dexpected_exit_code=1
+      "-Dpattern=structured output requires a CLI action flag"
+      -P ${CMAKE_SOURCE_DIR}/cmake/run_with_expectations.cmake)
+
+  add_test(
+    NAME calculator_variables_empty
+    COMMAND ${CMAKE_COMMAND}
+      -Dcmd=$<TARGET_FILE:calculator>
+      "-Dargs=--no-color;--variables"
+      -Dexpected_exit_code=0
+      "-Dpattern=No variables stored"
+      -Dworking_directory=${TEST_WORKDIR_EMPTY_VARS}
       -P ${CMAKE_SOURCE_DIR}/cmake/run_with_expectations.cmake)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ Simple C++ project providing two command-line tools:
   - can convert between number bases (binary, decimal, hexadecimal),
   - supports matrix addition, subtraction, and multiplication from the interactive menu,
   - includes an integrated divisors-finder,
-  - and now offers a prime-factorization workflow that also stores the original number as a variable for later use.
+  - offers a prime-factorization workflow that also stores the original number as a variable for later use,
+  - prints its version without launching the menu, and can list persisted variables directly from the CLI.
 - `divisors`: a standalone program that lists the positive divisors of an integer.
 ## Quickstart
 
@@ -82,6 +83,7 @@ cmake --build build --config Release
 | Matrix operations        | Adds, subtracts, or multiplies matrices of arbitrary size with guided prompts that validate dimensions before computing. |
 | Divisor search           | Produces a sorted list of positive divisors for any integer (except 0). |
 | Prime factorization      | Breaks positive integers into their prime powers, displays them in readable form (optionally starting with `-1` for negatives), and stores the factored integer in the `prime_factorization` variable. |
+| Variable inspection      | `--variables` lists persisted variable names and values without opening the interactive menu. |
 | Variable persistence     | Menu option 7 lets you list/set/delete variables that are persisted in `vars.toml` and reused in subsequent evaluations. |
 
 ## Code structure
@@ -107,10 +109,12 @@ cmake --build build --config Release
 - `--square-root <value>` / `-sqrt <value>`: compute a single square root (fails for negative inputs).
 - `--convert <from> <to> <value>` / `-c <from> <to> <value>`: convert an integer from one base to another and print the result. Accepted bases are `2`, `10` and `16`.
 - `--prime-factorization <value>` / `-pf <value>`: display the prime factors of the given integer (falls back to `-1` for negatives).
+- `--variables` / `--list-variables`: print every persisted variable and its value.
 - `--batch <file.txt>` / `-b <file.txt>`: execute commands listed in a text file (one CLI invocation per line, comments starting with `#` are ignored). Batch files recognize helper directives such as `@set <variable>` (store the previous numeric result), `@input <variable>` (prompt for a value/expression and store it), `@include <file>` (process another batch file), `@if <expression>` / `@endif` (conditional execution, truthy = non-zero), and `@unset <variable>` (remove a stored variable).
 - `--output <format>`: emit structured responses (`json`, `xml`, or `yaml`) for CLI flags so scripts can parse the calculator output more easily.
+- `--version` / `-v`: display the calculator version and exit.
 
-All numeric CLI arguments (square root inputs, divisor targets, conversion bases/values, prime-factorization targets) accept variable names that were previously defined either via the menu or in batch mode via `@set`, `@input`, or an included file.
+All numeric CLI arguments (square root inputs, divisor targets, conversion bases/values, prime-factorization targets) accept variable names that were previously defined either via the menu or in batch mode via `@set`, `@input`, or an included file. Structured output formats require a one-shot CLI flag (they are rejected if only `--output` is provided without an action).
 
 ## Variables
 

--- a/cmake/run_with_expectations.cmake
+++ b/cmake/run_with_expectations.cmake
@@ -8,6 +8,11 @@ foreach(var IN ITEMS cmd args expected_exit_code pattern)
 endforeach()
 
 # Execute the command with the provided arguments
+set(_working_directory_args)
+if(DEFINED working_directory)
+  set(_working_directory_args WORKING_DIRECTORY ${working_directory})
+endif()
+
 execute_process(
   COMMAND ${cmd} ${args}
   RESULT_VARIABLE actual_exit_code
@@ -15,6 +20,7 @@ execute_process(
   ERROR_VARIABLE cmd_stderr
   OUTPUT_STRIP_TRAILING_WHITESPACE
   ERROR_STRIP_TRAILING_WHITESPACE
+  ${_working_directory_args}
 )
 
 # Check exit code

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,12 +35,15 @@ set(COMMON_INCLUDES
 
 add_library(calculator_core ${CORE_SOURCES})
 target_include_directories(calculator_core PUBLIC ${COMMON_INCLUDES})
+target_compile_definitions(calculator_core PUBLIC CLI_CALCULATOR_VERSION="${PROJECT_VERSION}")
 
 add_executable(divisors ${TOOLS_SOURCES})
 add_executable(calculator ${APP_SOURCES})
 
 target_link_libraries(divisors PRIVATE calculator_core)
 target_link_libraries(calculator PRIVATE calculator_core)
+target_compile_definitions(divisors PRIVATE CLI_CALCULATOR_VERSION="${PROJECT_VERSION}")
+target_compile_definitions(calculator PRIVATE CLI_CALCULATOR_VERSION="${PROJECT_VERSION}")
 
 if(MSVC)
   target_compile_options(divisors PRIVATE /W4)

--- a/src/app/cli_actions.cpp
+++ b/src/app/cli_actions.cpp
@@ -9,6 +9,7 @@
 std::optional<int> handleCommandLine(int argc, char **argv)
 {
     OutputFormat outputFormat = OutputFormat::Text;
+    bool hasNonColorArgs = false;
 
     for (int i = 1; i < argc; ++i)
     {
@@ -43,6 +44,11 @@ std::optional<int> handleCommandLine(int argc, char **argv)
                 return 1;
             }
             ++i;
+            hasNonColorArgs = true;
+        }
+        else
+        {
+            hasNonColorArgs = true;
         }
     }
 
@@ -164,6 +170,35 @@ std::optional<int> handleCommandLine(int argc, char **argv)
             }
             return runPrimeFactorization(argv[i + 1], outputFormat);
         }
+
+        if (arg == "--version" || arg == "-v")
+        {
+            return runVersion(outputFormat);
+        }
+
+        if (arg == "--variables" || arg == "--list-variables")
+        {
+            return runListVariables(outputFormat);
+        }
+
+        if (!arg.empty())
+        {
+            if (outputFormat == OutputFormat::Text)
+            {
+                std::cerr << RED << "Error: unknown argument: " << arg << RESET << '\n';
+            }
+            else
+            {
+                printStructuredError(std::cerr, outputFormat, "unknown-argument", "unknown argument: " + arg);
+            }
+            return 1;
+        }
+    }
+
+    if (outputFormat != OutputFormat::Text && hasNonColorArgs)
+    {
+        printStructuredError(std::cerr, outputFormat, "output", "structured output requires a CLI action flag");
+        return 1;
     }
 
     return std::nullopt;

--- a/src/app/cli_batch.cpp
+++ b/src/app/cli_batch.cpp
@@ -167,6 +167,14 @@ std::string normalizeBatchFlag(const std::string &flag)
     {
         return "--prime-factorization";
     }
+    if (stripped == "v" || stripped == "version")
+    {
+        return "--version";
+    }
+    if (stripped == "variables" || stripped == "list-variables")
+    {
+        return "--variables";
+    }
     if (stripped == "h" || stripped == "help")
     {
         return "--help";
@@ -290,6 +298,16 @@ int dispatchBatchCommand(const std::vector<std::string> &tokens,
         }
         state.lastResult.reset();
         return runPrimeFactorization(tokens[1], outputFormat);
+    }
+    if (flag == "--version")
+    {
+        state.lastResult.reset();
+        return runVersion(outputFormat);
+    }
+    if (flag == "--variables")
+    {
+        state.lastResult.reset();
+        return runListVariables(outputFormat);
     }
     if (flag == "--help")
     {

--- a/src/app/cli_commands.hpp
+++ b/src/app/cli_commands.hpp
@@ -10,4 +10,6 @@ int runSquareRoot(const std::string &number, OutputFormat outputFormat, std::opt
 int runDivisors(const std::string &input, OutputFormat outputFormat);
 int runConvert(const std::string &fromBaseStr, const std::string &toBaseStr, const std::string &valueStr, OutputFormat outputFormat);
 int runPrimeFactorization(const std::string &input, OutputFormat outputFormat);
+int runVersion(OutputFormat outputFormat);
+int runListVariables(OutputFormat outputFormat);
 int runHelp(OutputFormat outputFormat);


### PR DESCRIPTION
## Summary
- add CLI commands for displaying the calculator version and listing stored variables, including batch support and structured output
- harden flag handling by rejecting unknown options and requiring an action when structured output is requested
- propagate the build version macro, expand documentation, and extend tests plus helper scripts for new behaviors

## Testing
- cmake --build build
- ctest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ff96688d48329b2322a22c89e0be4)