### PR TITLE
Inputting zero for a divisor now requests another number

### DIFF
--- a/src/app/menu_handlers.cpp
+++ b/src/app/menu_handlers.cpp
@@ -622,6 +622,7 @@ void handleDivisors() {
     long long value = readInteger("Enter an integer (0 allowed): ");
     if (value == 0) {
       std::cout << RED << "Zero has infinitely many divisors." << RESET << '\n';
+      continue;
     } else {
       try {
         std::vector<long long> divisors = calculateDivisors(value);


### PR DESCRIPTION
This fixes #8. It does this by having the zero case, after printing the message continue the loop and ask for another number.